### PR TITLE
feat: make `github_token` not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can do multiple comments during the workflow execution via different identif
 | file | Filename of the message (file needs to be placed in `.github/workflows/`) | message or file | |
 | single_comment | Would you like to update the existing comment (if exists) instead of creating a new one every time? | no | true |
 | identifier | Identifier that we put a comment in the comment so that we can identify them | no | `GITHUB_ACTION_COMMENT_PR` |
-| github_token | Github token that we use to create/update commit | yes | |
+| github_token | GitHub token that we use to create/update commit | no | `process.env.GITHUB_TOKEN` |
 
 It's required to provide `message` or `file` input. If both are provided `message` input will be used.
 
@@ -97,9 +97,9 @@ steps:
 ### In action
 Checkout workflow in action in this repo, follow this [link](workflow).
 
-## Github token
+## GitHub token
 
-You can pass Github token two ways:
+You can pass GitHub token two ways:
 
 #### Via input
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,6 @@ inputs:
     default: 'GITHUB_ACTION_COMMENT_PR'
   github_token:
     description: 'Github token that is used for commenting'
-    required: true
 outputs:
   commented:
     description: 'Tells you if comment was added to the PR or not, boolean'


### PR DESCRIPTION
Awesome little action! I love the update comment feature! :green_heart:

Since you fall back to `process.env.GITHUB_SECRET`, this is ambiguous:
https://github.com/NejcZdovc/comment-pr/blob/3f9eab4b3f55fd3f22934a5be7ad80fd5f529925/index.js#L11

I also get the following error in my editor:

![](https://i.imgur.com/Lc2Kf1Q.png)