### PR TITLE
fix: bump node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ branding:
   icon: message-square
   color: orange
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 will soon be deprecated by Github Actions:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/